### PR TITLE
Library API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ nb-configuration.xml
 
 # .client has its own gitignore
 !pmp-client/.vscode
+
+*.db

--- a/example-service/README.md
+++ b/example-service/README.md
@@ -22,5 +22,5 @@ Note that _both_ these commands should be run in order to see changes in pmp-cor
 Changes to the example server itself only requires running the second command.
 
 The backing database runs on port 7050, and its web interface on port 7051, and can be accessed with the JDBC URL
-`jdbc:h2:tcp://localhost:7050/mem:pmptest`, with `sa` as both username and password.
+`jdbc:h2:tcp://localhost:7050/file:./database`, with `sa` as both username and password.
 PMP will create a table named `PARAMETER_MANAGEMENT` that stores all the parameters.

--- a/example-service/src/main/java/dk/nykredit/example/pmp/JettyServer.java
+++ b/example-service/src/main/java/dk/nykredit/example/pmp/JettyServer.java
@@ -1,12 +1,16 @@
 package dk.nykredit.example.pmp;
 
+import dk.nykredit.pmp.core.remote.PMPServer;
+import dk.nykredit.pmp.core.remote.PMPServerImpl;
 import org.eclipse.jetty.cdi.CdiDecoratingListener;
 import org.eclipse.jetty.cdi.CdiServletContainerInitializer;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.webapp.DecoratingListener;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.log.Log;
 import org.eclipse.jetty.util.log.Logger;
 import org.jboss.weld.environment.servlet.EnhancedListener;
+import org.jboss.weld.environment.servlet.Listener;
 
 public class JettyServer {
     private static final int SERVER_PORT = 40535;
@@ -40,9 +44,14 @@ public class JettyServer {
         cx.addBean(new ServletContextHandler.Initializer(cx,
                 new CdiServletContainerInitializer()));
 
+        // Either start a fresh Jetty server like this or add the handler from `PMPHandlerFactory.getHandler()` to
+        // an existing server
+        PMPServer pmpServer = new PMPServerImpl();
+
         LOGGER.info("Starting Jetty Server");
 
         server.start();
+        pmpServer.start();
         server.join();
         databaseInitializer.stopDatabase();
     }

--- a/example-service/src/main/resources/META-INF/persistence.xml
+++ b/example-service/src/main/resources/META-INF/persistence.xml
@@ -9,9 +9,9 @@
         <class>dk.nykredit.pmp.core.persistence.ParameterEntity</class>
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
         <properties>
-            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:pmptest;INIT=SET SCHEMA PUBLIC;DB_CLOSE_DELAY=-1;MODE=Oracle"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:file:./database;INIT=SET SCHEMA PUBLIC;DB_CLOSE_DELAY=-1;MODE=Oracle"/>
 
-            <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
+            <property name="jakarta.persistence.schema-generation.database.action" value="validate"/>
             <property name="jakarta.persistence.schema-generation.create-source" value="metadata"/>
             <property name="jakarta.persistence.schema-generation.drop-source" value="metadata"/>
             <property name="jakarta.persistence.schema-generation.create-database-schemas" value="true"/>
@@ -23,7 +23,7 @@
 
 
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.hbm2ddl.auto" value="validate"/>
             <property name="hibernate.show_sql" value="true"/>
             <property name="hibernate.jdbc.time_zone" value="CET"/>
             <property name="hibernate.cache.use_second_level_cache" value="false"/>

--- a/pmp-core/pom.xml
+++ b/pmp-core/pom.xml
@@ -7,6 +7,10 @@
         <version>0.0.2-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <org.eclipse.jetty.version>9.4.51.v20230217</org.eclipse.jetty.version>
+    </properties>
+
     <artifactId>pmp-core</artifactId>
     <packaging>jar</packaging>
 
@@ -35,6 +39,29 @@
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- API Dependencies -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-cdi</artifactId>
+            <version>${org.eclipse.jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${org.eclipse.jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <version>${org.eclipse.jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.servlet</groupId>
+            <artifactId>weld-servlet</artifactId>
+            <version>2.3.0.Final</version>
+            <scope>compile</scope>
         </dependency>
 
         <!--Test dependencies-->

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/persistence/ParameterEntity.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/persistence/ParameterEntity.java
@@ -1,6 +1,7 @@
 package dk.nykredit.pmp.core.persistence;
 
 
+import java.util.Map;
 import java.util.UUID;
 
 import javax.persistence.Column;
@@ -13,13 +14,14 @@ import javax.persistence.Table;
 import dk.nykredit.pmp.core.attribute.converter.StringToObjectConverter;
 import lombok.Getter;
 import lombok.Setter;
+import org.eclipse.jetty.util.ajax.JSON;
 
 
 @Entity
 @Table(name = "PARAMETER_MANAGEMENT")
 @Getter
 @Setter
-public class ParameterEntity {
+public class ParameterEntity implements JSON.Convertible {
     @Id
     @Column(name = "ID", length = 36)
     private String id;
@@ -38,5 +40,24 @@ public class ParameterEntity {
     @PrePersist
     public void generatedId() {
         this.id = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public void toJSON(JSON.Output output) {
+        output.add("name", this.getName());
+        // Is this evil?
+        output.add("value", this.getPValue().toString());
+        output.add("type", this.getType());
+        output.add("id", this.getId());
+    }
+
+    @Override
+    public void fromJSON(Map map) {
+        this.setName((String) map.get("name"));
+        // TODO: i am 98% sure that this will crash like instantly but we aren't using this function yet
+        // we should really just use the converters from `EntityParser`
+        this.setPValue(map.get("value"));
+        this.setType((String) map.get("type"));
+        this.setId((String) map.get("id"));
     }
 }

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPHandlerFactory.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPHandlerFactory.java
@@ -1,0 +1,7 @@
+package dk.nykredit.pmp.core.remote;
+
+import org.eclipse.jetty.server.Handler;
+
+public interface PMPHandlerFactory {
+    Handler getHandler();
+}

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPHandlerFactoryImpl.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPHandlerFactoryImpl.java
@@ -1,0 +1,27 @@
+package dk.nykredit.pmp.core.remote;
+
+import org.eclipse.jetty.cdi.CdiDecoratingListener;
+import org.eclipse.jetty.cdi.CdiServletContainerInitializer;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.jboss.weld.environment.servlet.EnhancedListener;
+
+public class PMPHandlerFactoryImpl implements PMPHandlerFactory {
+    @Override
+    public Handler getHandler() {
+        ServletContextHandler cx = new ServletContextHandler();
+        cx.setContextPath("/");
+        cx.addServlet(ParametersServlet.class, "/parameters");
+
+        // Initialize CDI
+        cx.setInitParameter(
+                CdiServletContainerInitializer.CDI_INTEGRATION_ATTRIBUTE,
+                CdiDecoratingListener.MODE);
+        cx.addBean(new ServletContextHandler.Initializer(cx,
+                new EnhancedListener()));
+        cx.addBean(new ServletContextHandler.Initializer(cx,
+                new CdiServletContainerInitializer()));
+
+        return cx;
+    }
+}

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPServer.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPServer.java
@@ -1,0 +1,6 @@
+package dk.nykredit.pmp.core.remote;
+
+public interface PMPServer {
+    void start();
+    void stop();
+}

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPServerImpl.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPServerImpl.java
@@ -1,0 +1,41 @@
+package dk.nykredit.pmp.core.remote;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+
+public class PMPServerImpl implements PMPServer {
+
+    // TODO: This can be injected but Weld is being rude :(
+    private final TrackerService trackerService = new TrackerServiceImpl();
+    private final PMPHandlerFactory handlerFactory = new PMPHandlerFactoryImpl();
+
+    private final Server server;
+    private final int port;
+
+    public PMPServerImpl() {
+        port = Integer.parseInt(System.getProperty("dk.nykredit.pmp.remote.port", "64017"));
+        server = new Server(port);
+    }
+
+    public void start() {
+
+        Handler handler = handlerFactory.getHandler();
+        server.setHandler(handler);
+
+        System.out.println("Starting PMP remote on port " + port);
+        try {
+            server.start();
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    public void stop() {
+        try {
+            server.stop();
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+}

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/ParametersServlet.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/ParametersServlet.java
@@ -1,0 +1,31 @@
+package dk.nykredit.pmp.core.remote;
+
+import dk.nykredit.pmp.core.persistence.ParameterEntity;
+import dk.nykredit.pmp.core.repository.ParameterRepository;
+import org.eclipse.jetty.util.ajax.JSON;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class ParametersServlet extends HttpServlet {
+
+    @Inject
+    ParameterRepository parameterRepository;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        List<ParameterEntity> entities = parameterRepository.getParameters();
+
+        String json = JSON.toString(Map.of("parameters", entities.toArray()));
+
+        res.setStatus(HttpServletResponse.SC_OK);
+        res.setContentType("application/json");
+        res.getWriter().write(json);
+    }
+}

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerService.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerService.java
@@ -1,0 +1,9 @@
+package dk.nykredit.pmp.core.remote;
+
+public interface TrackerService {
+    /**
+     * Announces to the tracker that the service has started
+     * @param url The url where the PMP API is available
+     */
+    void announce(String serviceUrl);
+}

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerServiceImpl.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerServiceImpl.java
@@ -1,0 +1,9 @@
+package dk.nykredit.pmp.core.remote;
+
+public class TrackerServiceImpl implements TrackerService {
+    @Override
+    public void announce(String serviceUrl) {
+        // TODO
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+}

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/repository/ParameterRepository.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/repository/ParameterRepository.java
@@ -3,11 +3,15 @@ package dk.nykredit.pmp.core.repository;
 
 import dk.nykredit.pmp.core.persistence.ParameterEntity;
 
+import java.util.List;
+
 public interface ParameterRepository {
 
     ParameterEntity getValueByName(String name);
 
     ParameterEntity persistParameterEntity(ParameterEntity entity);
+
+    List<ParameterEntity> getParameters();
 
     boolean checkIfParameterExists(String name);
 }

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/repository/ParameterRepositoryImpl.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/repository/ParameterRepositoryImpl.java
@@ -47,4 +47,9 @@ public class ParameterRepositoryImpl implements ParameterRepository {
         return (Boolean) query.getSingleResult();
     }
 
+    @Override
+    public List<ParameterEntity> getParameters() {
+        TypedQuery<ParameterEntity> query = em.createQuery("SELECT e from ParameterEntity e", ParameterEntity.class);
+        return query.getResultList();
+    }
 }


### PR DESCRIPTION
* Start another embedded Jetty server in the example service
* Put a `/parameters` endpoint, which allows listing all parameters
* Make the database use a file instead of RAM allowing for parameters to persist