### PR TITLE
Announce to tracker

### DIFF
--- a/pmp-core/pom.xml
+++ b/pmp-core/pom.xml
@@ -63,6 +63,11 @@
             <version>2.3.0.Final</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
 
         <!--Test dependencies-->
         <dependency>

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPServerImpl.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/PMPServerImpl.java
@@ -25,6 +25,14 @@ public class PMPServerImpl implements PMPServer {
         System.out.println("Starting PMP remote on port " + port);
         try {
             server.start();
+            // TODO: Get the right data about the service
+            System.out.println("Announcing to tracker");
+            boolean success = trackerService.announce("http://localhost:" + port + "/", "Test Service", "Test1");
+            if (success) {
+                System.out.println("Registered to tracker successfully");
+            } else {
+                throw new RuntimeException("Could not register PMP to tracker");
+            }
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerService.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerService.java
@@ -1,9 +1,16 @@
 package dk.nykredit.pmp.core.remote;
 
+import java.io.IOException;
+
 public interface TrackerService {
     /**
      * Announces to the tracker that the service has started
-     * @param url The url where the PMP API is available
+     *
+     * @param pmpRoot     The root path of the PMP API
+     * @param serviceName The name of the service
+     * @param environment The name of the environment the service is running in
+     *                                       TODO: Should this be an enum? Maybe it just comes from a file who knows
+     * @return Whether the service successfully contacted the tracker
      */
-    void announce(String serviceUrl);
+    boolean announce(String pmpRoot, String serviceName, String environment) throws IOException;
 }

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerServiceImpl.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerServiceImpl.java
@@ -1,9 +1,48 @@
 package dk.nykredit.pmp.core.remote;
 
+import okhttp3.*;
+import org.eclipse.jetty.util.ajax.JSON;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
 public class TrackerServiceImpl implements TrackerService {
+
+    private static final URL TRACKER_URL;
+    private static final OkHttpClient http = new OkHttpClient();
+
+    static {
+        try {
+            // TODO: Add the real URL here
+            String urlStr = System.getProperty("dk.nykredit.pmp.core.trackerurl", "http://localhost:45754");
+            TRACKER_URL = new URL(urlStr);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
-    public void announce(String serviceUrl) {
-        // TODO
-        throw new UnsupportedOperationException("Not yet implemented");
+    public boolean announce(String pmpRoot, String serviceName, String environment) throws IOException {
+        RequestBody body = RequestBody.create(JSON.toString(Map.of(
+                "pmpRoot", pmpRoot,
+                "name", serviceName,
+                "permissions", new String[0]
+        )), MediaType.get("application/json"));
+        URL url;
+        try {
+            url = new URL(TRACKER_URL, "/register");
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+        Request req = new Request.Builder()
+                .url(url)
+                .post(body)
+                .build();
+
+        try (Response res = http.newCall(req).execute()) {
+            return res.isSuccessful();
+        }
     }
 }

--- a/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerServiceImpl.java
+++ b/pmp-core/src/main/java/dk/nykredit/pmp/core/remote/TrackerServiceImpl.java
@@ -39,6 +39,7 @@ public class TrackerServiceImpl implements TrackerService {
         Request req = new Request.Builder()
                 .url(url)
                 .post(body)
+                .addHeader("pmp-enviroment", environment)
                 .build();
 
         try (Response res = http.newCall(req).execute()) {


### PR DESCRIPTION
Send an HTTP Request to the tracker on startup

The service information needs to be gotten from the correct place and the default address of the tracker needs to be fixed