### PR TITLE
Push dialog (temp)

### DIFF
--- a/pmp-client/src/features/changes/sidebar/ChangeList.tsx
+++ b/pmp-client/src/features/changes/sidebar/ChangeList.tsx
@@ -39,7 +39,7 @@ const ChangeList = () => {
             <div className='flex-none'>
                 <Grid style={{ padding: '0px', paddingRight: '0px', paddingLeft: '5px', paddingBottom: '5px' }}>
                     <GridCell span={7}>
-                        <Button raised={hasChanges} outlined={!hasChanges} disabled={!hasChanges}>
+                        <Button onClick={PushDialog} raised={hasChanges} outlined={!hasChanges} disabled={!hasChanges}>
                             Push to {environment}
                         </Button>
                     </GridCell>

--- a/pmp-client/src/features/changes/sidebar/ChangeList.tsx
+++ b/pmp-client/src/features/changes/sidebar/ChangeList.tsx
@@ -17,6 +17,8 @@ import ServiceChangeList from './ServiceChangeList';
 import { groupBy } from '../../../utils/array';
 import { isParameterChange } from '../commitStoreHelpers';
 import useCommitStore from '../useCommitStore';
+import PushDialog from './PushDialog';
+import { useState } from 'react';
 import useEnvironment from '../../environment/useEnvironment';
 
 /**
@@ -25,12 +27,13 @@ import useEnvironment from '../../environment/useEnvironment';
 const ChangeList = () => {
     const changes = useCommitStore((s) => s.changes);
     const clearChanges = useCommitStore((s) => s.clear);
-    const { environment } = useEnvironment();
-
     const parameterChanges = changes.filter(isParameterChange);
     const hasChanges = changes.length > 0;
     const serviceChanges = groupBy(parameterChanges, (c) => c.service.name);
     const sortedNames = Object.keys(serviceChanges).sort();
+    const [open, setOpen] = useState(false);
+    const { environment } = useEnvironment();
+    const showEnvironmentWarning = environment.startsWith('pre') || environment.startsWith('prod');
 
     // TODO: Implement push functionality
 
@@ -39,7 +42,18 @@ const ChangeList = () => {
             <div className='flex-none'>
                 <Grid style={{ padding: '0px', paddingRight: '0px', paddingLeft: '5px', paddingBottom: '5px' }}>
                     <GridCell span={7}>
-                        <Button onClick={PushDialog} raised={hasChanges} outlined={!hasChanges} disabled={!hasChanges}>
+                        <PushDialog
+                            environment={environment}
+                            showWarning={showEnvironmentWarning}
+                            open={open}
+                            onClose={() => setOpen(false)}
+                        />
+                        <Button
+                            onClick={() => setOpen(true)}
+                            raised={hasChanges}
+                            outlined={!hasChanges}
+                            disabled={!hasChanges}
+                        >
                             Push to {environment}
                         </Button>
                     </GridCell>

--- a/pmp-client/src/features/changes/sidebar/PushAccepted.tsx
+++ b/pmp-client/src/features/changes/sidebar/PushAccepted.tsx
@@ -1,0 +1,49 @@
+import { Dialog, DialogActions, DialogButton, DialogTitle } from 'rmwc';
+import usePushCommit from './usePushCommit';
+import useCommitStore from '../useCommitStore';
+
+interface PushAcceptedProps {
+    open: boolean;
+    onClose?: () => void;
+}
+
+const PushAccepted = ({ open, onClose }: PushAcceptedProps) => {
+    // TODO: Missing implementation: usePushCommit currently only returns true.
+    // It should check whether the push can get done or not.
+    // Also actual backend implementation is missing to change params on services.
+    // Finally, the parameters are currently just reverted back to their original values.
+    const accepted = usePushCommit();
+    const clearChanges = useCommitStore((s) => s.clear);
+
+    if (accepted) {
+        console.log('In accepted component');
+        return (
+            <>
+                <Dialog open={open} onClose={onClose} onOpen={clearChanges}>
+                    <DialogTitle>Changes pushed succesfully</DialogTitle>
+                    <DialogActions>
+                        <DialogButton danger outlined action='accept'>
+                            OK
+                        </DialogButton>
+                    </DialogActions>
+                </Dialog>
+            </>
+        );
+    } else {
+        console.log('In discarded component');
+        return (
+            <>
+                <Dialog open={open} onClose={onClose}>
+                    <DialogTitle>Applying changes was unsuccesful</DialogTitle>
+                    <DialogActions>
+                        <DialogButton danger outlined action='accept'>
+                            OK
+                        </DialogButton>
+                    </DialogActions>
+                </Dialog>
+            </>
+        );
+    }
+};
+
+export default PushAccepted;

--- a/pmp-client/src/features/changes/sidebar/PushDialog.tsx
+++ b/pmp-client/src/features/changes/sidebar/PushDialog.tsx
@@ -1,6 +1,59 @@
-const PushDialog = () => {
+import { useState } from 'react';
+import { Dialog, DialogActions, DialogButton, DialogContent, DialogTitle, TextField, Typography } from 'rmwc';
+import PushAccepted from './PushAccepted';
+
+interface PushDialogProps {
+    open: boolean;
+    onClose?: () => void;
+    showWarning: boolean;
+    environment: string;
+}
+
+const PushDialog = ({ environment, open, onClose, showWarning }: PushDialogProps) => {
+    const [input, setInput] = useState('');
+    const isInputValid = input === environment;
+    const [openNextDialog, setOpenNextDialog] = useState(false);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setInput(e.target.value);
+    };
 
     return (
-
+        <>
+            <Dialog open={open} onClose={onClose} onClosed={() => setInput('')}>
+                <DialogTitle>Push Pending Changes</DialogTitle>
+                <DialogContent>
+                    <Typography use='headline6'>Are you sure you want to push the current pending changes?</Typography>
+                    {showWarning && (
+                        <>
+                            <div>
+                                <TextField
+                                    label={'Enter  "' + environment + '" to confirm'}
+                                    value={input}
+                                    onChange={handleInputChange}
+                                />
+                            </div>
+                        </>
+                    )}
+                </DialogContent>
+                <DialogActions>
+                    <DialogButton raised action='close' isDefaultAction>
+                        Cancel
+                    </DialogButton>
+                    <DialogButton
+                        danger
+                        outlined
+                        action='accept'
+                        disabled={showWarning && !isInputValid}
+                        onClick={() => setOpenNextDialog(true)}
+                    >
+                        Push
+                    </DialogButton>
+                </DialogActions>
+            </Dialog>
+            <PushAccepted open={openNextDialog} onClose={() => setOpenNextDialog(false)} />
+        </>
     );
 };
+
+export default PushDialog;

--- a/pmp-client/src/features/changes/sidebar/PushDialog.tsx
+++ b/pmp-client/src/features/changes/sidebar/PushDialog.tsx
@@ -1,0 +1,6 @@
+const PushDialog = () => {
+
+    return (
+
+    );
+};

--- a/pmp-client/src/features/changes/sidebar/usePushCommit.ts
+++ b/pmp-client/src/features/changes/sidebar/usePushCommit.ts
@@ -1,0 +1,5 @@
+const usePushCommit = () => {
+    return true;
+};
+
+export default usePushCommit;


### PR DESCRIPTION
Possibly scuffed implementation of dialogs to push button.

Current functionality displays prompt on push. It includes a text field in which you need to write the name of the environment if it is pre-prod or prod. When the changes are attempted to be pushed another prompt displays whether it is successful or not. If they are successful (which it always is since the function to confirm it always returns true) the changes are reverted to their original values.

MISSING IMPLEMENTATION:
Sending a request to see if the changes can be pushed or not.
Actually changing the parameters to their new values

This commit is primarily to provide necessary functionality for the user tests.